### PR TITLE
add async api

### DIFF
--- a/nyct_gtfs/feed.py
+++ b/nyct_gtfs/feed.py
@@ -2,6 +2,7 @@ import datetime
 from urllib.parse import urlparse, unquote
 
 import requests
+import httpx
 
 from nyct_gtfs.compiled_gtfs import nyct_subway_pb2, gtfs_realtime_pb2
 from nyct_gtfs.gtfs_static_types import TripShapes, Stations
@@ -124,6 +125,17 @@ class NYCTFeed:
             raise RuntimeError(f"Error accessing MTA data feed: {response.content}")
 
         self.load_gtfs_bytes(response.content)
+
+    async def refresh_async(self):
+        """Reload this object's feed information from the MTA API async"""
+        async with httpx.AsyncClient() as client:
+            response = await client.get(self._feed_url, headers={'x-api-key':self._api_key})
+            if response.status_code == 403:
+                raise RuntimeError(f"Invalid API key: {self._api_key}")
+            elif response.status_code != 200:
+                raise RuntimeError(f"Error accessing MTA data feed: {response.content}")
+
+            self.load_gtfs_bytes(response.text)
 
     def load_gtfs_bytes(self, gtfs_bytes, cpp_accelerated=False):
         """

--- a/nyct_gtfs/feed.py
+++ b/nyct_gtfs/feed.py
@@ -135,7 +135,7 @@ class NYCTFeed:
             elif response.status_code != 200:
                 raise RuntimeError(f"Error accessing MTA data feed: {response.content}")
 
-            self.load_gtfs_bytes(response.text)
+            self.load_gtfs_bytes(response.content)
 
     def load_gtfs_bytes(self, gtfs_bytes, cpp_accelerated=False):
         """

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     package_data={
         "nyct_gtfs": ["gtfs_static/*.txt"]
     },
-    install_requires=["requests", "protobuf"]
+    install_requires=["requests", "protobuf", "httpx"]
 )


### PR DESCRIPTION
This PR adds a hidden async api to the protocol. 

to use it, the `refresh_async` method must be called instead of `refresh`. the user should also probably set `fetch_immediately` to False in the constructor.

Tested working here:
https://github.com/kinto0/kyles-rgb-matrix/blob/async/train_api.py