### PR TITLE
Account for trip IDs missing shape IDs

### DIFF
--- a/nyct_gtfs/trip.py
+++ b/nyct_gtfs/trip.py
@@ -265,7 +265,8 @@ class Trip:
 
         For example, a Southbound 1 train might have a shape ID of: "1..S03R"
         """
-        return self.trip_id.split('_')[1]
+        parts = self.trip_id.split('_')
+        return parts[1] if len(parts) > 1 else None
 
     @property
     def direction(self):
@@ -275,7 +276,10 @@ class Trip:
         Returns either "N" for northbound trains (and Grand Central bound shuttles) or "S" for southbound trains
         (and Times Square bound shuttles)
         """
-        return self.shape_id.split('..')[1][0] if '..' in self.trip_id else self.shape_id.split('.')[1][0]
+        parts = self.shape_id.split('.')
+        if '..' in self.trip_id:
+            parts = self.shape_id('..')
+        return parts[1][0] if len(parts) > 1 else None
 
     @property
     def departure_time(self):

--- a/nyct_gtfs/trip.py
+++ b/nyct_gtfs/trip.py
@@ -276,8 +276,10 @@ class Trip:
         Returns either "N" for northbound trains (and Grand Central bound shuttles) or "S" for southbound trains
         (and Times Square bound shuttles)
         """
+        if not self.shape_id:
+            return None
         parts = self.shape_id.split('.')
-        if '..' in self.trip_id:
+        if '..' in self.shape_id:
             parts = self.shape_id('..')
         return parts[1][0] if len(parts) > 1 else None
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="nyct-gtfs",
-    version="1.3.0",
+    version="1.3.1",
     description="Real-time NYC subway data parsing for humans",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
When the shape ID is missing, the direction
cannot be parsed. It shows up as a 0 after _

Fixes #2 