### PR TITLE
Pin protobuf to last ver with RegisterExtension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     package_data={
         "nyct_gtfs": ["gtfs_static/*.txt"]
     },
-    install_requires=["requests", "protobuf", "httpx"]
+    install_requires=["requests", "protobuf==4.25.3", "httpx"]
 )


### PR DESCRIPTION
RegisterExtension was deprecated and removed in
version 5 and above of protobuf. Building without
pinning results in errors.

Fixes #4 