### PR TITLE
Expose the realtime and nyct subway raw messages

### DIFF
--- a/nyct_gtfs/__init__.py
+++ b/nyct_gtfs/__init__.py
@@ -2,3 +2,4 @@ from nyct_gtfs.feed import NYCTFeed
 from nyct_gtfs.trip import Trip
 from nyct_gtfs.stop_time_update import StopTimeUpdate
 from nyct_gtfs.gtfs_static_types import Stations, TripShapes
+from nyct_gtfs.compiled_gtfs import nyct_subway_pb2, gtfs_realtime_pb2

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     package_data={
         "nyct_gtfs": ["gtfs_static/*.txt"]
     },
-    install_requires=["requests", "protobuf", "httpx"]
+    install_requires=["requests", "protobuf==4.25.3", "httpx"]
 )


### PR DESCRIPTION
In order to use these for other formats (that are not subways), the first choice is to use the gtfs-realtime-bindings project (part of Google Transit now managed by MobilityData). However, in doing so, because both the compiled version in this repo and the version provided by gtfs-realtime-bindings use the same Default() descriptor pool, there is a duplicate conflict.

However, the newer version probably doesn't support the extensions, per the changes to protobuf after v5 as discussed in the other PR about pinning. 

So the easy (temporary?) fix appears to be to just expose these so they can be used directly without the additional logic specific to subways.

For example, the raw feed can be used for ferries, buses, trollies, and the like. 

I have tested this with the NYC Ferry service gifs realtime feed successfully.