### PR TITLE
Remove Unnecessary API Key Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See "Usage Examples" below for more examples of the data available.
 * [MTA GTFS-realtime Data Feeds](https://api.mta.info/)
 
 ## Installation
-* Update Version 2.0.0: API keys are no longer required to access MTA GTFS feeds. [Learn more.](https://api.mta.info/#/)
+*Update Version 2.0.0: API keys are no longer required to access MTA GTFS feeds. [Learn more.](https://api.mta.info/#/)*
 1. Install nyct-gtfs
    ```sh
    pip install nyct-gtfs

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ However, with NYCT-GTFS, you can access and query this data in just a few lines 
 >>> from nyct_gtfs import NYCTFeed
 
 # Load the realtime feed from the MTA site
->>> feed = NYCTFeed("1", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed = NYCTFeed("1")
 
 # Get all 123 trains currently underway to Times Sq-42 St
 >>> trains = feed.filter_trips(line_id=["1", "2", "3"], headed_for_stop_id=["127N", "127S"], underway=True)
@@ -50,18 +50,17 @@ See "Usage Examples" below for more examples of the data available.
 * [MTA GTFS-realtime Data Feeds](https://api.mta.info/)
 
 ## Installation
-
-1. Get a free MTA API Key at [https://api.mta.info/](https://api.mta.info/#/signup)
-2. Install nyct-gtfs
+* Update Version 2.0.0: API keys are no longer required to access MTA GTFS feeds. [Learn more.](https://api.mta.info/#/)
+1. Install nyct-gtfs
    ```sh
    pip install nyct-gtfs
    ```
-3. Load the data feed
+2. Load the data feed
     ```python
     from nyct_gtfs import NYCTFeed
     
     # Load the realtime feed from the MTA site
-    feed = NYCTFeed("1", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+    feed = NYCTFeed("1")
     ```
 
 ## Usage Examples
@@ -69,7 +68,7 @@ See "Usage Examples" below for more examples of the data available.
 ### Get All Trip Data from the Feed
 ```python
 >>> from nyct_gtfs import NYCTFeed
->>> feed = NYCTFeed("B", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed = NYCTFeed("B")
 
 # Read all trip (train) information published to the BDFM feed 
 >>> trains = feed.trips
@@ -81,7 +80,7 @@ See "Usage Examples" below for more examples of the data available.
 ### Filter Only Certain Trip Data from the Feed
 ```python
 >>> from nyct_gtfs import NYCTFeed
->>> feed = NYCTFeed("B", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed = NYCTFeed("B")
 
 # Read only D train information from the BDFM feed 
 >>> trains = feed.filter_trips(line_id="D")
@@ -102,7 +101,7 @@ See `NYCTFeed.filter_trips()` for a complete listing of the filtering options av
 ### Read Trip/Train Metadata
 ```python
 >>> from nyct_gtfs import NYCTFeed
->>> feed = NYCTFeed("N", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed = NYCTFeed("N")
 
 # Read the first train from the feed
 >>> train = feed.trips[0]
@@ -142,7 +141,7 @@ departure from the station listed. Therefore our southbound N train from the pre
 in its scheduled stops list:
 ```python
 >>> from nyct_gtfs import NYCTFeed
->>> feed = NYCTFeed("N", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed = NYCTFeed("N")
 
 # Read the first train from the feed
 >>> train = feed.trips[0]
@@ -164,7 +163,7 @@ in its scheduled stops list:
 #### Read stop details
 ```python
 >>> from nyct_gtfs import NYCTFeed
->>> feed = NYCTFeed("N", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed = NYCTFeed("N")
 
 # Read the first train from the feed
 >>> train = feed.trips[0]
@@ -188,7 +187,7 @@ For full details about stop time fields see `StopTimeUpdate`
 
 ```python
 >>> from nyct_gtfs import NYCTFeed
->>> feed = NYCTFeed("A", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed = NYCTFeed("A")
 
 # Get the timestamp the GTFS feed was generated at
 >>> feed.last_generated
@@ -225,7 +224,7 @@ dict_keys(['A', 'C', 'E', 'H', 'FS'])
 ### Refresh Feed Data
 ```python
 >>> from nyct_gtfs import NYCTFeed
->>> feed = NYCTFeed("A", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed = NYCTFeed("A")
 
 # Pick a train to get details from
 >>> train = feed.trips[0]
@@ -250,11 +249,11 @@ NYCT Subway feeds are grouped by color for all of the B division (lettered) line
 are grouped into a single feed. When you initialize an `NYCTFeed` object, you can specify a line or feed URL, e.g:
 ```python
 >>> from nyct_gtfs import NYCTFeed
->>> feed1 = NYCTFeed("A", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed1 = NYCTFeed("A")
 
->>> feed2 = NYCTFeed("C", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed2 = NYCTFeed("C")
 
->>> feed3 = NYCTFeed("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace", api_key="YOUR_MTA_API_KEY_GOES_HERE")
+>>> feed3 = NYCTFeed("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace")
 
 >>> feed1.trip_replacement_periods.keys()
 dict_keys(['A', 'C', 'E', 'H', 'FS'])

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="nyct-gtfs",
-    version="1.3.3",
+    version="2.0.0",
     description="Real-time NYC subway data parsing for humans",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/gtfs_parse_test.py
+++ b/tests/gtfs_parse_test.py
@@ -1,11 +1,8 @@
-import os
-from datetime import datetime, timedelta
-
 from nyct_gtfs import NYCTFeed
 
 
 def main():
-    feed = NYCTFeed("2", api_key=os.environ['API_KEY'])
+    feed = NYCTFeed("2")
     trips = feed.filter_trips(line_id=["2", "3"], travel_direction="N")
     print(trips[3])
 

--- a/tests/gtfs_parse_test_local.py
+++ b/tests/gtfs_parse_test_local.py
@@ -1,11 +1,8 @@
-import os
-from datetime import datetime, timedelta
-
 from nyct_gtfs import NYCTFeed
 
 
 def main():
-    feed = NYCTFeed("2", api_key=None, fetch_immediately=False)
+    feed = NYCTFeed("2", fetch_immediately=False)
     with open('test_data/2_delay.nyct.gtfsrt', 'rb') as f:
         feed.load_gtfs_bytes(f.read())
     trips = feed.filter_trips(line_id=["2"], travel_direction="N", has_delay_alert=True)

--- a/tests/test_feed_parse.py
+++ b/tests/test_feed_parse.py
@@ -8,7 +8,7 @@ from nyct_gtfs.compiled_gtfs import gtfs_realtime_pb2, nyct_subway_pb2
 class TestFeedParseADivision(unittest.TestCase):
     def setUp(self) -> None:
         with open('test_data/a_division.nyct.gtfsrt', 'rb') as f:
-            self.feed = NYCTFeed('1', api_key=None, fetch_immediately=False)
+            self.feed = NYCTFeed('1', fetch_immediately=False)
             self.feed.load_gtfs_bytes(f.read())
 
     def test_feed_header(self):
@@ -227,7 +227,7 @@ class TestParseCustomStaticFiles(unittest.TestCase):
         with open('test_data/a_division.nyct.gtfsrt', 'rb') as f:
             with open('../nyct_gtfs/gtfs_static/stops.txt', 'r') as stops:
                 with open('../nyct_gtfs/gtfs_static/trips.txt', 'r') as trips:
-                    self.feed = NYCTFeed('1', api_key=None, fetch_immediately=False, stops_txt=stops, trips_txt=trips)
+                    self.feed = NYCTFeed('1', fetch_immediately=False, stops_txt=stops, trips_txt=trips)
                     self.feed.load_gtfs_bytes(f.read())
 
     def test_read_from_trips(self):
@@ -241,14 +241,14 @@ class TestParseCustomStaticFiles(unittest.TestCase):
 
 class TestFeedConstructor(unittest.TestCase):
     def test_feed_constructor_bogus_feed(self):
-        self.assertRaises(ValueError, NYCTFeed, "alskfjdk", api_key=None, fetch_immediately=False)
+        self.assertRaises(ValueError, NYCTFeed, "alskfjdk", fetch_immediately=False)
 
     def test_feed_constructor_ace(self):
-        ace_feed = NYCTFeed("A", api_key=None, fetch_immediately=False)
+        ace_feed = NYCTFeed("A", fetch_immediately=False)
         self.assertEqual("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace", ace_feed._feed_url)
 
     def test_feed_constructor_ace_link(self):
-        ace_feed = NYCTFeed("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace", api_key=None,
+        ace_feed = NYCTFeed("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace",
                             fetch_immediately=False)
         self.assertEqual("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace", ace_feed._feed_url)
 
@@ -256,7 +256,7 @@ class TestFeedConstructor(unittest.TestCase):
 class TestFeedParseBDivision(unittest.TestCase):
     def setUp(self) -> None:
         with open('test_data/b_division.nyct.gtfsrt', 'rb') as f:
-            self.feed = NYCTFeed('1', api_key=None, fetch_immediately=False)
+            self.feed = NYCTFeed('1', fetch_immediately=False)
             self.feed.load_gtfs_bytes(f.read())
 
     def test_fake_underway(self):
@@ -276,7 +276,7 @@ class TestFeedParseBDivision(unittest.TestCase):
 class TestFeedParseDelayAlerts(unittest.TestCase):
     def setUp(self) -> None:
         with open('test_data/2_delay.nyct.gtfsrt', 'rb') as f:
-            self.feed = NYCTFeed('2', api_key=None, fetch_immediately=False)
+            self.feed = NYCTFeed('2', fetch_immediately=False)
             self.feed.load_gtfs_bytes(f.read())
 
     def test_feed_filtering(self):
@@ -294,7 +294,7 @@ class TestFeedParseDelayAlerts(unittest.TestCase):
 class TestFeedFiltering(unittest.TestCase):
     def setUp(self) -> None:
         with open('test_data/a_division.nyct.gtfsrt', 'rb') as f:
-            self.feed = NYCTFeed('1', api_key=None, fetch_immediately=False)
+            self.feed = NYCTFeed('1', fetch_immediately=False)
             self.feed.load_gtfs_bytes(f.read())
 
     def test_feed_filtering(self):
@@ -343,7 +343,7 @@ class TestFeedFiltering(unittest.TestCase):
 class TestBadTripShape(unittest.TestCase):
     def setUp(self) -> None:
         with open('test_data/2_train_with_0_shape.nyct.gtfsrt', 'rb') as f:
-            self.feed = NYCTFeed('1', api_key=None, fetch_immediately=False)
+            self.feed = NYCTFeed('1', fetch_immediately=False)
             self.feed.load_gtfs_bytes(f.read())
 
     def test_bad_trip_shape_doesnt_cause_exception(self):

--- a/tests/test_feed_parse_cpp.py
+++ b/tests/test_feed_parse_cpp.py
@@ -8,7 +8,7 @@ from nyct_gtfs.compiled_gtfs import gtfs_realtime_pb2, nyct_subway_pb2
 class TestFeedParseADivision(unittest.TestCase):
     def setUp(self) -> None:
         with open('test_data/a_division.nyct.gtfsrt', 'rb') as f:
-            self.feed = NYCTFeed('1', api_key=None, fetch_immediately=False)
+            self.feed = NYCTFeed('1', fetch_immediately=False)
             self.feed.load_gtfs_bytes(f.read(), cpp_accelerated=True)
 
     def test_feed_header(self):
@@ -86,7 +86,6 @@ class TestFeedParseADivision(unittest.TestCase):
         for stop in remaining_stops:
             self.assertEqual('4', stop.scheduled_track)
             self.assertEqual(False, stop.unexpected_track_arrival)
-
 
     def test_train_parse_assigned(self):
         trip = self.feed.trips[22]
@@ -227,7 +226,7 @@ class TestParseCustomStaticFiles(unittest.TestCase):
         with open('test_data/a_division.nyct.gtfsrt', 'rb') as f:
             with open('../nyct_gtfs/gtfs_static/stops.txt', 'r') as stops:
                 with open('../nyct_gtfs/gtfs_static/trips.txt', 'r') as trips:
-                    self.feed = NYCTFeed('1', api_key=None, fetch_immediately=False, stops_txt=stops, trips_txt=trips)
+                    self.feed = NYCTFeed('1', fetch_immediately=False, stops_txt=stops, trips_txt=trips)
                     self.feed.load_gtfs_bytes(f.read(), cpp_accelerated=True)
 
     def test_read_from_trips(self):
@@ -241,14 +240,14 @@ class TestParseCustomStaticFiles(unittest.TestCase):
 
 class TestFeedConstructor(unittest.TestCase):
     def test_feed_constructor_bogus_feed(self):
-        self.assertRaises(ValueError, NYCTFeed, "alskfjdk", api_key=None, fetch_immediately=False)
+        self.assertRaises(ValueError, NYCTFeed, "alskfjdk", fetch_immediately=False)
 
     def test_feed_constructor_ace(self):
-        ace_feed = NYCTFeed("A", api_key=None, fetch_immediately=False)
+        ace_feed = NYCTFeed("A", fetch_immediately=False)
         self.assertEqual("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace", ace_feed._feed_url)
 
     def test_feed_constructor_ace_link(self):
-        ace_feed = NYCTFeed("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace", api_key=None,
+        ace_feed = NYCTFeed("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace",
                             fetch_immediately=False)
         self.assertEqual("https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace", ace_feed._feed_url)
 
@@ -256,7 +255,7 @@ class TestFeedConstructor(unittest.TestCase):
 class TestFeedParseBDivision(unittest.TestCase):
     def setUp(self) -> None:
         with open('test_data/b_division.nyct.gtfsrt', 'rb') as f:
-            self.feed = NYCTFeed('1', api_key=None, fetch_immediately=False)
+            self.feed = NYCTFeed('1', fetch_immediately=False)
             self.feed.load_gtfs_bytes(f.read(), cpp_accelerated=True)
 
     def test_fake_underway(self):
@@ -273,10 +272,11 @@ class TestFeedParseBDivision(unittest.TestCase):
         self.assertEqual('Inwood-207 St', self.feed.trips[0].headsign_text)
         self.assertEqual('A..N', self.feed.trips[0].shape_id)
 
+
 class TestFeedParseDelayAlerts(unittest.TestCase):
     def setUp(self) -> None:
         with open('test_data/2_delay.nyct.gtfsrt', 'rb') as f:
-            self.feed = NYCTFeed('2', api_key=None, fetch_immediately=False)
+            self.feed = NYCTFeed('2', fetch_immediately=False)
             self.feed.load_gtfs_bytes(f.read(), cpp_accelerated=True)
 
     def test_feed_filtering(self):
@@ -294,7 +294,7 @@ class TestFeedParseDelayAlerts(unittest.TestCase):
 class TestFeedFiltering(unittest.TestCase):
     def setUp(self) -> None:
         with open('test_data/a_division.nyct.gtfsrt', 'rb') as f:
-            self.feed = NYCTFeed('1', api_key=None, fetch_immediately=False)
+            self.feed = NYCTFeed('1', fetch_immediately=False)
             self.feed.load_gtfs_bytes(f.read(), cpp_accelerated=True)
 
     def test_feed_filtering(self):


### PR DESCRIPTION
Per [MTA's website](https://api.mta.info/#/), API keys are no longer needed to access the GTFS feed.

> Accounts and API keys are no longer required to access these feeds.

This PR removes the unnecessary `api_key` field in `NYCTFeed` along with all associated references.